### PR TITLE
Use json to save metdata for db entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.pickle
+/db/*/*.json
 *~
 *.pyc
 Magdir

--- a/README
+++ b/README
@@ -58,7 +58,7 @@ $ sudo rpm -U my-file.prm my-file-libs.rpm ...
 ------------------------------
 
 Fast regression test tests the output of the currently installed File and
-compares it to the one stored in db/*/*.pickle files. If there's a significant
+compares it to the one stored in db/*/*.json files. If there's a significant
 difference (see HOW DOES IT WORK) between the output, it's showed as FAIL.
 
 $ python fast-regression-test.py
@@ -118,12 +118,12 @@ Then all files in the db directory are detected. During the detection,
 particular pattern responsible for detection is found using the bisection
 method.
 
-All metadata are stored into ./db/*/*.pickle file.
+All metadata are stored into ./db/*/*.json file.
 
 3.2: fast-regression-test.py script:
 ------------------------------------
 
-This script simply gets metadata stored in the ./db/*/*.pickle files and
+This script simply gets metadata stored in the ./db/*/*.json files and
 compares them with the output of the current File version.
 
 In non-exact mode, regressions are detected using the Ratcliff/Obershelp

--- a/convert-pickle-db.py
+++ b/convert-pickle-db.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+""" Convert metdata saved as .pickle (old format) to json (the new format).
+
+Use this if there are .pickle files in your db/ folder
+
+.. codeauthor:: Intra2net AG <opensource@intra2net.com>
+"""
+
+import sys
+import os
+from os.path import isfile
+import pickle
+from pyfile.db import set_stored_metadata, get_stored_files
+
+
+def main():
+    """
+    Main function, called when running file as script
+
+    see module doc for more info
+    """
+    # get all names of files (except .json, .source.txt) in db
+    # (luckily, there is no .pickle nor .json as entry in db)
+    entries = get_stored_files("db")
+
+    # loop over all entries
+    n_errors = 0
+    n_converted = 0
+    for entry in entries:
+        # continue if there is no pickle with saved metadata
+        old_filename = entry + '.pickle'
+        if not isfile(old_filename):
+            continue
+
+        try:
+            # unpickle stored metadata, save as json
+            with open(old_filename, 'r') as file_handle:
+                metadata = pickle.load(file_handle)
+            set_stored_metadata(entry, metadata)
+
+            # remove pickle
+            os.unlink(old_filename)
+            n_converted += 1
+        except Exception as exc:
+            print('Could not convert {}: {}'.format(entry, exc))
+            n_errors += 1
+
+    print('Converted {} entries, {} conversion attempts failed'
+          .format(n_converted, n_errors))
+
+    return 1 if n_errors else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pyfile/db.py
+++ b/pyfile/db.py
@@ -20,23 +20,28 @@
 
 
 import os
-import pickle
+import json
 import difflib
 import mimetypes
 from cStringIO import StringIO
 mimetypes.init()
 
 
+# suffix for files containing saved metadata
+DB_FILE_SUFFIX = '.json'
+
+
 def get_stored_metadata(filename):
     """Retrieve metadata stored for given entry in db."""
-    with open(filename + ".pickle", 'r') as file_handle:
-        return pickle.load(file_handle)
+    with open(filename + DB_FILE_SUFFIX, 'rt') as file_handle:
+        return json.load(file_handle)
 
 
 def set_stored_metadata(filename, metadata):
     """Store given metadata for given entry in db."""
-    with open(filename + ".pickle", 'w') as file_handle:
-        pickle.dump(metadata, file_handle)
+    with open(filename + DB_FILE_SUFFIX, 'wt') as file_handle:
+        json.dump(metadata, file_handle, check_circular=False, indent=4,
+                  sort_keys=True)
 
 
 def is_regression(meta1, meta2, exact=False, ratio=0.7):
@@ -168,7 +173,7 @@ def get_stored_files(dir_name, subdir=True, *args):
         dirfile = os.path.join(dir_name, file_name)
         if os.path.isfile(dirfile):
             if not args:
-                if not dirfile.endswith("pickle") and \
+                if not dirfile.endswith(DB_FILE_SUFFIX) and \
                         not dirfile.endswith(".source.txt"):
                     file_list.append(dirfile)
             else:

--- a/pyfile/db.py
+++ b/pyfile/db.py
@@ -176,6 +176,7 @@ def get_stored_files(dir_name, subdir=True, *args):
                 if not dirfile.endswith(DB_FILE_SUFFIX) and \
                         not dirfile.endswith(".source.txt"):
                     file_list.append(dirfile)
+                # TODO: also exclude .json (or .json.json in dir "json")
             else:
                 if os.path.splitext(dirfile)[1][1:] in args:
                     file_list.append(dirfile)

--- a/runtest.sh
+++ b/runtest.sh
@@ -30,7 +30,7 @@ SLEEP_TIME="1234567890123456789012345678901234567890123456789012345678"
 
 #    rlPhaseStartTest
 # this test tests one file at time
-	for f in `find db/ -type f |grep -v ".pickle$"`; do  
+	for f in `find db/ -type f |grep -v ".json$"`; do  
 	    python test-file.py $f
 	done
 # this tests all files in 4 threads and is much more faster

--- a/test-file.py
+++ b/test-file.py
@@ -20,7 +20,6 @@ import os
 import sys
 import errno
 from subprocess import Popen, PIPE
-import pickle
 import mimetypes
 import difflib
 from pyfile import *

--- a/test-rpmbuild-regression.py
+++ b/test-rpmbuild-regression.py
@@ -20,7 +20,6 @@ import os
 import sys
 import errno
 from subprocess import Popen, PIPE
-import pickle
 import mimetypes
 import difflib
 from pyfile import *
@@ -59,7 +58,7 @@ def test_attr(attr):
 
 	if regex and path:
 		for f in os.listdir(path):
-			if f.endswith("pickle"):
+			if f.endswith("json"):
 				continue
 			full_path = os.path.join(path, f)
 			output = get_simple_metadata(full_path)['output']


### PR DESCRIPTION
This used to be pickle, changed for these reasons:
- pickle is unsafe (malicious pickles can execute code upon unpickling)
- json is much easier to read for humans (and other programming languages)
- in json we can fix the order of fields, so diffs between versions of saved
  metadata show actual changes instead of arbitrary swaps of field order

See also: issue #8 